### PR TITLE
Removed Word doc links

### DIFF
--- a/index-fr.html
+++ b/index-fr.html
@@ -49,14 +49,8 @@
 	    <div class="col-md-6">
         <h2 class="h3">Documents</h2>
         <ul>
-          <li><a href="fr/directives-relatives-aux-documents-accessibles-Office365/comment-creer-des-documents-accessibles-365.html" id="dda365">Directives relatives aux documents accessibles&nbsp;: Office&nbsp;365</a>
-            <ul>
-              <li><a href="https://1drv.ms/u/s!AoQ9zmenRIM-gWfpD5uu90-V8sSe?e=uhJoYI" rel="external" id="dda365w" aria-labelledby="dda365w dda365">Télécharger&nbsp;: formats Word</a></li>
-            </ul></li>
-          <li><a href="fr/directives-relatives-aux-documents-accessibles-Office2016/comment-creer-des-documents-accessibles.html" id="dda2016">Directives relatives aux documents accessibles&nbsp;: Office&nbsp;2016</a>
-            <ul>
-              <li><a href="https://1drv.ms/u/s!AoQ9zmenRIM-gUyO83X0F-QSUAdU?e=ayj6Hi" rel="external" id="dda2016w" aria-labelledby="dda2016w dda2016">Télécharger&nbsp;: formats Word</a></li>
-            </ul></li>
+          <li><a href="fr/directives-relatives-aux-documents-accessibles-Office365/comment-creer-des-documents-accessibles-365.html">Directives relatives aux documents accessibles&nbsp;: Office&nbsp;365</a></li>
+          <li><a href="fr/directives-relatives-aux-documents-accessibles-Office2016/comment-creer-des-documents-accessibles.html">Directives relatives aux documents accessibles&nbsp;: Office&nbsp;2016</a></li>
   	    </ul>
         <h2 class="h3">Formulaires</h2>
         <ul>

--- a/index.html
+++ b/index.html
@@ -49,14 +49,8 @@
     	    <div class="col-md-6">
       	    <h2 class="h3">Documents</h2>
             <ul>
-              <li><a href="en/accessible-documents-guides-Office365/how-to-create-accessible-documents-365.html" id="da1">Accessible document guides: Office 365</a>
-                <ul>
-                  <li><a href="https://1drv.ms/u/s!AoQ9zmenRIM-gWZrWVy8mHWTy3sh?e=Z2NoFl" rel="external" id="da1w" aria-labelledby="da1w da1">Download Word formats</a></li>
-                </ul></li>
-              <li><a href="en/accessible-documents-guides-Office2016/how-to-create-accessible-documents.html" id="da2">Accessible document guides: Office 2016</a>
-                <ul>
-                  <li><a href="https://1drv.ms/u/s!AoQ9zmenRIM-gUs4UGL7Bv6njTH6?e=GpEGra" rel="external" id="da2w" aria-labelledby="da2w da2">Download Word formats</a></li>
-                </ul></li>
+              <li><a href="en/accessible-documents-guides-Office365/how-to-create-accessible-documents-365.html">Accessible document guides: Office 365</a></li>
+              <li><a href="en/accessible-documents-guides-Office2016/how-to-create-accessible-documents.html">Accessible document guides: Office 2016</a></li>
       	    </ul>
 
             <h2 class="h3">Forms</h3>


### PR DESCRIPTION
Removed links to word docs for Removed Document Accessibility guides. HTML is not the primary format.